### PR TITLE
Fixed: Adapter::dev_id was always 0 → always used the first adapter.

### DIFF
--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -489,7 +489,7 @@ impl Adapter {
         info!("DevInfo: {:?}", di);
         Adapter {
             name: String::from(unsafe { CStr::from_ptr(di.name.as_ptr()).to_str().unwrap() }),
-            dev_id: 0,
+            dev_id: di.dev_id,
             addr: di.bdaddr,
             typ: AdapterType::parse((di.type_ & 0x30) >> 4),
             states: AdapterState::parse(di.flags),


### PR DESCRIPTION
I noticed this on my system with two adapters: hci0 and hci1. Before the change scanning with rumble didn't work if hci0 wasn't available (*), even if I connected to hci1.

(*) it was included in the list of adapters, but another process was using it.